### PR TITLE
Added Curl to the runtime dependencies to allow for easier scripting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get install -y alsa-utils
 RUN apt-get install -y --no-install-recommends pulseaudio-utils
 RUN apt-get install -y ca-certificates
 RUN apt-get install -y libavahi-compat-libdnssd1
+RUN apt-get install -y curl
     
 RUN	rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This is all that needs to be changed for the issue I raised to be resolved.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added one line of code to add curl to the installed packages.

## Motivation and Context
Proposed as it makes using librespots on_event script trigger better

## How Has This Been Tested?
Tested on a raspberry pi 4, it just worked, no issues came up.

## Screenshots (if appropriate):
