### PR TITLE
Build using tag v0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,14 +23,11 @@ RUN apt-get install -y git
 
 RUN mkdir /src
 WORKDIR /src
-RUN git clone --branch master https://github.com/librespot-org/librespot.git
+RUN git clone --depth 1 --branch v0.6.0 https://github.com/librespot-org/librespot.git
 WORKDIR /src/librespot
 RUN CARGO_NET_GIT_FETCH_WITH_CLI=true cargo build --release --no-default-features --features "alsa-backend pulseaudio-backend with-avahi with-dns-sd with-libmdns"
 RUN cp /src/librespot/target/release/librespot /usr/bin/librespot
 WORKDIR /
-# RUN rm -Rf /src
-
-RUN rm -rf /var/lib/apt/lists/*
 
 FROM ${BASE_IMAGE:-library/debian:stable-slim} AS intermediate
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Just be careful to use the tag you have built.
 
 Change Date|Major Changes
 ---|---
+2025-01-27|Build latest tag v0.6.0 instead of default branch
 2025-01-26|Added curl to the runtime dependencies (see [#113](https://github.com/GioF71/librespot-docker/issues/113))
 2025-01-03|Restored arm/v7 build
 2025-01-03|Build using cargo (see [#103](https://github.com/GioF71/librespot-docker/issues/103))


### PR DESCRIPTION
Use tag v0.6.0 instead of the default branch.